### PR TITLE
Fixed rhf_forces

### DIFF
--- a/pyqint/hf.py
+++ b/pyqint/hf.py
@@ -241,6 +241,7 @@ class HF:
         # intialization
         integrator = PyQInt()
         cgfs, nuclei = mol.build_basis(basis)
+        n_elec = np.sum([nucleus[1] for nucleus in nuclei])
         forces = np.zeros(shape = [len(mol.atoms), 3])
         n = len(cgfs)
     
@@ -249,7 +250,7 @@ class HF:
         ew_density = np.zeros(shape = [n, n])
         for i in range(n):
             for j in range(n):
-                for k in range(0, len(e)//2):
+                for k in range(0, n_elec//2):
                     ew_density[i,j] += 2.0 * e[k] * C[i,k] * C[j,k]
 
         # Loop over all cartesian direction for every nucleus

--- a/pyqint/hf.py
+++ b/pyqint/hf.py
@@ -275,7 +275,11 @@ class HF:
                         
                         # derivative nuclear electron attraction
                         for nucleus in mol.nuclei:
-                            nuclear[i, j] += integrator.nuclear_deriv(cgf_1, cgf_2, nucleus[0], nucleus[1], deriv_nucleus[0], deriv_direction)
+                            
+                            # nuclear_deriv_op returns wrong values if both cgfs and nucleus is on deriv_nucleus
+                            # the following if statment eliminates that term using translational symmetry 
+                            if not (np.linalg.norm(cgf_1.p - deriv_nucleus[0]) < 0.0001 and  np.linalg.norm(cgf_2.p - deriv_nucleus[0]) < 0.0001 and np.linalg.norm(nucleus[0] - deriv_nucleus[0]) < 0.0001):
+                                nuclear[i, j] += integrator.nuclear_deriv(cgf_1, cgf_2, nucleus[0], nucleus[1], deriv_nucleus[0], deriv_direction)
 
                         # derivative of electron-electron repulsions
                         for k, cgf_3 in enumerate(cgfs):

--- a/pyqint/integrals.cpp
+++ b/pyqint/integrals.cpp
@@ -497,12 +497,12 @@ double Integrator::nuclear_deriv_bf(const GTO& gto1, const GTO& gto2, const vec3
                                         gto2.get_position(), gto2.get_l(), gto2.get_m(), gto2.get_n(), gto2.get_alpha(), nucleus);
         gto_ang[coord] += 1; // recover l
 
-        return -2.0 * gto1.get_alpha() * term_plus + gto_ang[coord] * term_min;
+        return 2.0 * gto1.get_alpha() * term_plus - gto_ang[coord] * term_min;
     } else { // s-type GTO
         gto_ang[coord] += 1;
         double term1 = this->nuclear(gto1.get_position(), gto_ang[0], gto_ang[1], gto_ang[2], gto1.get_alpha(),
                                      gto2.get_position(), gto2.get_l(), gto2.get_m(), gto2.get_n(), gto2.get_alpha(), nucleus);
-        return -2.0 * gto1.get_alpha() * term1;
+        return 2.0 * gto1.get_alpha() * term1;
     }
 }
 


### PR DESCRIPTION
The three commits fix erroneous behaviour of rhf_forces by:

1) Resolving an issue in `rhf_forces` using wrong bounds for the calculation of the energy weighted density matrix.
2) Inverting a wrong sign in `nuclear_deriv_bf` in intergals.cpp.
3) Implementing translational symmetry relations to avoid computation of terms where `nuclear_deriv_op` fails.